### PR TITLE
chore: automatically keep the major version tag up to date

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -1,0 +1,16 @@
+name: Keep the major version tag up-to-date
+
+on:
+  release:
+    types: [published, edited]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  update-major-tag:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: Actions-R-Us/actions-tagger@v2


### PR DESCRIPTION
Copied from: https://github.com/wearerequired/git-mirror-action/blob/master/.github/workflows/versioning.yml